### PR TITLE
fix : modify ItemOption annotation (#17)

### DIFF
--- a/src/main/java/iampotato/iampotato/domain/itemoption/domain/ItemOption.java
+++ b/src/main/java/iampotato/iampotato/domain/itemoption/domain/ItemOption.java
@@ -21,7 +21,7 @@ public class ItemOption {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Column(name = "item_id")
+    @JoinColumn(name = "item_id")
     private Item item;
 
     private ItemOptionCategory category; // 사이즈, 토핑추가, 맵기정도 등 카테고리 구분하기 위함


### PR DESCRIPTION
## 🔢 이슈 번호
- #17 

<br/>

## ⚙ 이슈 사항
- `ItemOption.class` 에 `@manyToOne `어노테이션의 경우 `@Column` 이어서 오류 발생

<br/>

## 📁 관련 파일
- `ItemOption`

<br/>

## ✔ 해결 방법
- `@Column` -> `@JoinColumn` 으로 수정


<br/>

## 📷 스크린샷
- X