### PR TITLE
Refactor/change response dto(#40)

### DIFF
--- a/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
@@ -6,6 +6,7 @@ import iampotato.iampotato.domain.customer.domain.Customer;
 import iampotato.iampotato.domain.customer.dto.SignUpRequest;
 import iampotato.iampotato.domain.customer.dto.SignUpResponse;
 import iampotato.iampotato.domain.customer.dto.UploadImageResponse;
+import iampotato.iampotato.global.util.Result;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,7 +28,7 @@ public class CustomerApi {
     private final CustomerImageService customerImageService;
 
     @PostMapping("/api/v1/customers")
-    public SignUpResponse signUp(@RequestBody SignUpRequest signUpRequest) throws Exception{    //회원 가입하는 POST API
+    public Result<SignUpResponse> signUp(@RequestBody SignUpRequest signUpRequest) throws Exception{    //회원 가입하는 POST API
         //Spring security로 Password Hash 암호화 로직 추가하기
         Customer customer = Customer.builder()
                 .loginId(signUpRequest.getLoginId())
@@ -35,7 +36,7 @@ public class CustomerApi {
                 .nickname(signUpRequest.getNickname())
                 .build();
         Long id = customerSignUpService.signUp(customer);
-        return new SignUpResponse(id);
+        return new Result<>(Result.CODE_SUCCESS,Result.MESSAGE_OK, new SignUpResponse(id));
     }
 
     @PutMapping("/api/v1/customers/{id}/image") //MultipartFile을 처리하기 위해서 @RequestParam을 사용했다. 따라서 {image:이미지파일} 꼴로 넘겨 받아야한다.

--- a/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
@@ -40,9 +40,9 @@ public class CustomerApi {
     }
 
     @PutMapping("/api/v1/customers/{id}/image") //MultipartFile을 처리하기 위해서 @RequestParam을 사용했다. 따라서 {image:이미지파일} 꼴로 넘겨 받아야한다.
-    public UploadImageResponse uploadImage(@PathVariable("id") Long customerId, @RequestParam(value="image", required=false) MultipartFile multipartFile) throws Exception {
+    public Result<UploadImageResponse> uploadImage(@PathVariable("id") Long customerId, @RequestParam(value="image", required=false) MultipartFile multipartFile) throws Exception {
         Customer customer = customerImageService.uploadImage(customerId, multipartFile);
-        return new UploadImageResponse(customerId, customer.getCustomerImage());
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, new UploadImageResponse(customerId, customer.getCustomerImage()));
     }
 
     @GetMapping(value = "/image/view", produces = {"image/jpeg", "image/png", "image/gif"})

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
     password: sayingpotato1!
   jpa:
     hibernate:
-      ddl-auto: none #create로 하면 애플리케이션 실행 시점에 내가 가지고 있는 테이블을 다 지운 다음에 엔티티 정보를 보고 테이블을 자동으로 만들어 줌
+      ddl-auto: create #create로 하면 애플리케이션 실행 시점에 내가 가지고 있는 테이블을 다 지운 다음에 엔티티 정보를 보고 테이블을 자동으로 만들어 줌
     properties:
       hibernate:
         #          show_sql: true #밑에 org.hivernate.SQL과 겹치는데 얘는 System.out으로 찍는 거고 밑에는 로그로 찍는거. 얘를 안쓰는 걸 추천


### PR DESCRIPTION
## 🔢 이슈 번호
- https://github.com/sayingpotato/Backend/issues/40

<br/>

## ⚙ 이슈 사항
- 이번에 Response 객체 리팩토링을 통해서 Global util의 통일된 템플릿의 response로 교체하는 작업이 있었습니다. 이에 따라 지금까지 생성된 response object를 global util response로 패키징하는 작업을 진행하였습니다.
- 추가적으로 application-dev.yml이 개발용 배포의 설정 파일인데 ddl-auto가 none으로 되어있어서 테이블 변경 작업 진행 시 업데이트가 되지 않는 번거로움이 있었습니다. 이에 따라 create 모드로 바꿔 배포하도록 수정하였습니다. (create 모드 사용시 spring boot application이 새로 실행될 때마다 table을 모두 drop한 뒤 새롭게 재생성)

<br/>

## 📁 관련 파일
- CustomerApi
- application-dev.yml

<br/>

## ✔ 해결 방법
- CustomerApi에 reponse들을 global>util>Result 객체로 패키징하여 제공
- application-dev.yml의 ddl-auto를 create 모드로 변경

<br/>

## 📷 스크린샷
- 없습니다.