### PR TITLE
Feat/make exception strategy(#52)

### DIFF
--- a/src/main/java/iampotato/iampotato/domain/store/api/StoreApi.java
+++ b/src/main/java/iampotato/iampotato/domain/store/api/StoreApi.java
@@ -1,6 +1,5 @@
 package iampotato.iampotato.domain.store.api;
 
-import iampotato.iampotato.domain.discount.domain.DiscountDay;
 import iampotato.iampotato.domain.store.application.StoreService;
 import iampotato.iampotato.domain.store.domain.Location;
 import iampotato.iampotato.domain.store.domain.Store;
@@ -87,8 +86,7 @@ public class StoreApi {
     @GetMapping("api/v1/stores/discount")
     public Result<List<StoreTodayDiscountResponse>> findStoresByDiscountDayForTodayDiscount(StoreTodayDiscountRequest storeTodayDiscountRequest) {
 
-        DiscountDay discountDay = DiscountDay.valueOf(storeTodayDiscountRequest.getDay());
-        List<Store> todayDiscountStores = storeService.findStoresByDiscountDay(discountDay);
+        List<Store> todayDiscountStores = storeService.findStoresByDiscountDay(storeTodayDiscountRequest.getDay());
 
         List<StoreTodayDiscountResponse> storeTodayDiscountResponses = todayDiscountStores.stream()
                 .map(StoreTodayDiscountResponse::new)

--- a/src/main/java/iampotato/iampotato/domain/store/application/StoreService.java
+++ b/src/main/java/iampotato/iampotato/domain/store/application/StoreService.java
@@ -4,12 +4,15 @@ import iampotato.iampotato.domain.discount.domain.DiscountDay;
 import iampotato.iampotato.domain.store.dao.StoreRepository;
 import iampotato.iampotato.domain.store.domain.Location;
 import iampotato.iampotato.domain.store.domain.Store;
+import iampotato.iampotato.domain.store.exception.StoreException;
+import iampotato.iampotato.domain.store.exception.StoreExceptionGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 
 @Service
@@ -30,7 +33,10 @@ public class StoreService {
     }
 
     public Store findByIdV2(Long storeId, int offset, int limit) {
-        return storeRepository.findByIdV2(storeId, offset, limit);
+
+        Optional<Store> OptionalStore = storeRepository.findByIdV2(storeId, offset, limit);
+
+        return OptionalStore.orElseThrow(() -> new StoreException(StoreExceptionGroup.STORE_NULL));
     }
 
 

--- a/src/main/java/iampotato/iampotato/domain/store/dto/todaydiscount/StoreTodayDiscountRequest.java
+++ b/src/main/java/iampotato/iampotato/domain/store/dto/todaydiscount/StoreTodayDiscountRequest.java
@@ -1,13 +1,14 @@
 package iampotato.iampotato.domain.store.dto.todaydiscount;
 
+import iampotato.iampotato.domain.discount.domain.DiscountDay;
 import lombok.Data;
 
 @Data
 public class StoreTodayDiscountRequest {
 
-    String day;
+    DiscountDay day;
 
-    public StoreTodayDiscountRequest(String day) {
+    public StoreTodayDiscountRequest(DiscountDay day) {
         this.day = day;
     }
 }

--- a/src/main/java/iampotato/iampotato/domain/store/exception/StoreException.java
+++ b/src/main/java/iampotato/iampotato/domain/store/exception/StoreException.java
@@ -1,0 +1,13 @@
+package iampotato.iampotato.domain.store.exception;
+
+import lombok.Getter;
+
+@Getter
+public class StoreException extends RuntimeException {
+
+    private final StoreExceptionGroup storeExceptionGroup;
+
+    public StoreException(StoreExceptionGroup storeExceptionGroup) {
+        this.storeExceptionGroup = storeExceptionGroup;
+    }
+}

--- a/src/main/java/iampotato/iampotato/domain/store/exception/StoreExceptionGroup.java
+++ b/src/main/java/iampotato/iampotato/domain/store/exception/StoreExceptionGroup.java
@@ -1,0 +1,19 @@
+package iampotato.iampotato.domain.store.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum StoreExceptionGroup {
+
+    STORE_NULL(400, "S001", "가게가 없습니다.");
+
+    private final int httpCode;
+    private final String errorCode;
+    private final String message;
+
+    StoreExceptionGroup(int httpCode, String errorCode, String message) {
+        this.httpCode = httpCode;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/iampotato/iampotato/global/exception/ExceptionController.java
+++ b/src/main/java/iampotato/iampotato/global/exception/ExceptionController.java
@@ -1,0 +1,51 @@
+package iampotato.iampotato.global.exception;
+
+import iampotato.iampotato.domain.store.exception.StoreException;
+import iampotato.iampotato.global.util.ErrorResult;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(StoreException.class)
+    public ErrorResult StoreExceptionHandler(StoreException e) {
+        return new ErrorResult(e.getStoreExceptionGroup().getHttpCode(),
+                e.getStoreExceptionGroup().getErrorCode(),
+                e.getStoreExceptionGroup().getMessage());
+    }
+
+    /**
+     * MethodArgumentNotValidException.class
+     * &#064;Valid 사용시에 @RequestBody 어노테이션으로 받은 파라미터의 경우 호출되는 예외입니다.
+     * BindException.class
+     * &#064;Valid  사용시 @ModelAttribute 어노테이션으로 받은 파라미터의 경우 발생하는 예외입니다.
+     * 그 외에도 enum 에서 바인딩이 안될시 호출되는 예외입니다.
+     * 예를들어 json 으로 온 값이 enum 값에 매핑되는게 없을시 호출됩니다.
+     * 참고로 MethodArgumentNotValidException.class 는 BindException 을 상속받은 것입니다.
+     */
+    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+    public List<ErrorResult> MethodArgNotValidExceptionHandler(BindException e) {
+
+        BindingResult bindingResult = e.getBindingResult();
+        List<ErrorResult> errorResults = new ArrayList<>();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            ValidExceptionGroup validExceptionGroup = ValidExceptionGroup.findValidError(fieldError.getCode());
+            errorResults.add(new ErrorResult(validExceptionGroup.getHttpCode(),
+                    validExceptionGroup.getErrorCode(),
+                    validExceptionGroup.getMessage()));
+
+        }
+
+        return errorResults;
+    }
+
+}

--- a/src/main/java/iampotato/iampotato/global/exception/ValidExceptionGroup.java
+++ b/src/main/java/iampotato/iampotato/global/exception/ValidExceptionGroup.java
@@ -1,0 +1,50 @@
+package iampotato.iampotato.global.exception;
+
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * 해당 예외는 @Valid 사용시 발생하는 예외에 대해 설정해주는곳입니다.
+ * 만약 @Valid 를 사용해서 없는 예외라면 여기에 추가해주면 됩니다.
+ */
+@Getter
+public enum ValidExceptionGroup {
+
+    NOT_NULL("NotNull",400,"G001", "값이 비어있을 수 없습니다."),
+    MIN_VALUE("Min",400,"G002", "해당 값을 최소값보다 작습니다."),
+    TYPE_MISMATCH("typeMismatch",400,"G003", "요청한 타입은 존재하지 않습니다."),
+    NONE("", 400, "G999", "설정되지 않은 에러");
+
+    private final String validName;
+    private final int httpCode;
+    private final String errorCode;
+    private final String message;
+
+    private static final Map<String, ValidExceptionGroup> cashMap =
+            Collections.unmodifiableMap(Stream.of(values())
+                    .collect(Collectors.toMap(ValidExceptionGroup::getValidName, Function.identity())));
+
+    ValidExceptionGroup(String validName, int httpCode, String errorCode, String message) {
+        this.validName = validName;
+        this.httpCode = httpCode;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public static ValidExceptionGroup findValidError(String name) {
+        return Optional.ofNullable(cashMap.get(name)).orElse(NONE);
+    }
+
+//    public ValidExceptionGroup findValidError(String name) {
+//        return Arrays.stream(values())
+//                .filter(ex -> ex.getValidName().equals(name))
+//                .findAny()
+//                .orElse(NONE);
+//    }
+}

--- a/src/main/java/iampotato/iampotato/global/util/ErrorResult.java
+++ b/src/main/java/iampotato/iampotato/global/util/ErrorResult.java
@@ -1,0 +1,16 @@
+package iampotato.iampotato.global.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResult {
+
+    public static final int CODE_CLIENT_ERROR = 400;
+    public static final int CODE_SERVER_ERROR = 500;
+
+    private int httpCode;
+    private String errorCode;
+    private String message;
+}

--- a/src/main/java/iampotato/iampotato/global/util/Result.java
+++ b/src/main/java/iampotato/iampotato/global/util/Result.java
@@ -16,10 +16,8 @@ public class Result<T> {
     public static final int CODE_CONTINUE = 100;
     public static final int CODE_SUCCESS = 200;
     public static final int CODE_REDIRECT = 300;
-    public static final int CODE_CLIENT_ERROR = 400;
-    public static final int CODE_SERVER_ERROR = 500;
 
-    private int code;
+    private int httpCode;
     private String message;
     private T data;
 }


### PR DESCRIPTION
## 🔢 이슈 번호
- #52

<br/>

## ⚙ 이슈 사항
- 예외처리 전략 추가
- @ControllerAdvice 를 활용한 글로벌 예외처리를 추가했습니다. 모든 예외는 해당 컨트롤러클래스를 거치게됩니다.
- @Valid 예외도 잡아서 설정된 포맷으로 변환하여 반환합니다.
- 도메인별로 예외와 예외 그룹을 만들어서 예외처리를 할 수 있도록 했습니다.
- 예외처리 전략이 수립됨에 따라 일부 클래스가 수정됬습니다.

<br/>

## 📁 관련 파일
- ErrorResult
- Result
- StoreException
- StoreExcetpionGroup
- ExceptionController
- ValidExceptionGroup
- StoreApi
- StoreService
- StoreRepository
- StoreTodayDiscountRequest

<br/>

## ✔ 해결 방법
- x

<br/>

## 📷 스크린샷
- x