### PR TITLE
Refactor/apply global exception(#62)

### DIFF
--- a/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignInService.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignInService.java
@@ -3,6 +3,8 @@ package iampotato.iampotato.domain.customer.application;
 import iampotato.iampotato.domain.customer.dao.CustomerRepository;
 import iampotato.iampotato.domain.customer.domain.Customer;
 import iampotato.iampotato.domain.customer.dto.TokenResponse;
+import iampotato.iampotato.domain.customer.exception.CustomerException;
+import iampotato.iampotato.domain.customer.exception.CustomerExceptionGroup;
 import iampotato.iampotato.domain.customer.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,13 +28,13 @@ public class CustomerSignInService {
     public TokenResponse signIn(String loginId, String password) {
         List<Customer> findCustomersByLoginId = customerRepository.findByLoginId(loginId);
         if (findCustomersByLoginId.isEmpty()) {
-            throw new IllegalStateException("존재하지 않는 아이디입니다.");
+            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_ID_NULL);
         }
 
         Customer customer = findCustomersByLoginId.get(0);
 
         if (!customer.getPassword().equals(password)) {
-            throw new IllegalStateException("비밀번호가 일치하지 않습니다.");
+            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_PASSWORD_WRONG);
         }
 
         // 1. Login ID/PW 를 기반으로 Authentication 객체 생성

--- a/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignUpService.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignUpService.java
@@ -2,6 +2,8 @@ package iampotato.iampotato.domain.customer.application;
 
 import iampotato.iampotato.domain.customer.dao.CustomerRepository;
 import iampotato.iampotato.domain.customer.domain.Customer;
+import iampotato.iampotato.domain.customer.exception.CustomerException;
+import iampotato.iampotato.domain.customer.exception.CustomerExceptionGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,18 +25,18 @@ public class CustomerSignUpService {
         return customer.getId();
     }
 
-    private void validateDuplicatedCustomerByLoginId(Customer customer) throws Exception{
+    private void validateDuplicatedCustomerByLoginId(Customer customer) {
         List<Customer> findCustomersByLoginId = customerRepository.findByLoginId(customer.getLoginId());
         if (!findCustomersByLoginId.isEmpty()) {
-            throw new IllegalStateException("이미 존재하는 아이디입니다.");
+            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_DUPLICATED_ID);
         }
     }
 
-    private void validateDuplicatedCustomerByNickname(Customer customer) throws Exception{
+    private void validateDuplicatedCustomerByNickname(Customer customer) {
         List<Customer> findCustomersByNickname = customerRepository.findByNickname(customer.getNickname());
 
         if (!findCustomersByNickname.isEmpty()) {
-            throw new IllegalStateException("이미 존재하는 닉네임입니다.");
+            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_DUPLICATED_NICKNAME);
         }
     }
 

--- a/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
@@ -1,5 +1,7 @@
 package iampotato.iampotato.domain.customer.domain;
 
+import iampotato.iampotato.domain.customer.exception.CustomerException;
+import iampotato.iampotato.domain.customer.exception.CustomerExceptionGroup;
 import lombok.*;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hibernate.annotations.GenericGenerator;
@@ -78,7 +80,7 @@ public class Customer implements UserDetails {
 
     public CustomerImage parseImageInfo(MultipartFile multipartFile) throws Exception {
         if (multipartFile.isEmpty()) {  //들어오는 이미지 파일이 비어있으면 예외 메세지 출력하고 상위 호출 메서드로 예외를 던짐
-            throw new IllegalStateException("이미지 파일이 비어있습니다.");
+            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_IMAGE_NULL);
         }
 
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd");
@@ -100,7 +102,7 @@ public class Customer implements UserDetails {
         String contentType = multipartFile.getContentType();    //확장자를 판단하기 위해
         String fileExtension;   //이미지 파일의 확장자를 저장
         if (ObjectUtils.isEmpty(contentType)) { //확장자 명이 없는지 검사
-            throw new IllegalStateException("이미지 파일의 확장자가 존재하지 않는 잘못된 파일입니다.");
+            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_IMAGE_EXTENSION_NULL);
         } else {
             if (contentType.contains("image/jpeg")) {
                 fileExtension = ".jpg";
@@ -109,7 +111,7 @@ public class Customer implements UserDetails {
             } else if (contentType.contains("image/gif")) {
                 fileExtension = ".gif";
             } else {
-                throw new IllegalStateException("이미지 파일의 확장자가 허용되지 않는 확장자입니다. jpg, png, gif 파일만 사용 가능합니다.");
+                throw new CustomerException(CustomerExceptionGroup.CUSTOMER_IMAGE_EXTENSION_WRONG);
             }
         }
 

--- a/src/main/java/iampotato/iampotato/domain/customer/exception/CustomerException.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/exception/CustomerException.java
@@ -1,0 +1,14 @@
+package iampotato.iampotato.domain.customer.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomerException extends RuntimeException{
+
+    private final CustomerExceptionGroup customerExceptionGroup;
+
+    public CustomerException(CustomerExceptionGroup customerExceptionGroup) {
+        this.customerExceptionGroup = customerExceptionGroup;
+    }
+
+}

--- a/src/main/java/iampotato/iampotato/domain/customer/exception/CustomerExceptionGroup.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/exception/CustomerExceptionGroup.java
@@ -1,0 +1,25 @@
+package iampotato.iampotato.domain.customer.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum CustomerExceptionGroup {
+
+    CUSTOMER_ID_NULL(400, "C001", "존재하지 않는 아이디입니다."),
+    CUSTOMER_PASSWORD_WRONG(400, "C002", "비밀번호가 일치하지 않습니다."),
+    CUSTOMER_DUPLICATED_ID(400, "C003", "이미 존재하는 아이디입니다."),
+    CUSTOMER_DUPLICATED_NICKNAME(400, "C004", "이미 존재하는 닉네임입니다."),
+    CUSTOMER_IMAGE_NULL(400, "C005", "이미지 파일이 비어있습니다."),
+    CUSTOMER_IMAGE_EXTENSION_NULL(400, "C006", "이미지 파일의 확장자가 존재하지 않는 잘못된 파일입니다."),
+    CUSTOMER_IMAGE_EXTENSION_WRONG(400, "C007", "이미지 파일의 확장자가 허용되지 않는 확장자입니다. jpg, png, gif 파일만 사용 가능합니다.");
+
+    private final int httpCode;
+    private final String errorCode;
+    private final String message;
+
+    CustomerExceptionGroup(int httpCode, String errorCode, String message) {
+        this.httpCode = httpCode;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/iampotato/iampotato/global/exception/ExceptionController.java
+++ b/src/main/java/iampotato/iampotato/global/exception/ExceptionController.java
@@ -1,5 +1,6 @@
 package iampotato.iampotato.global.exception;
 
+import iampotato.iampotato.domain.customer.exception.CustomerException;
 import iampotato.iampotato.domain.store.exception.StoreException;
 import iampotato.iampotato.global.util.ErrorResult;
 import org.springframework.validation.BindException;
@@ -20,6 +21,13 @@ public class ExceptionController {
         return new ErrorResult(e.getStoreExceptionGroup().getHttpCode(),
                 e.getStoreExceptionGroup().getErrorCode(),
                 e.getStoreExceptionGroup().getMessage());
+    }
+
+    @ExceptionHandler(CustomerException.class)
+    public ErrorResult CustomerExceptionHandler(CustomerException e) {
+        return new ErrorResult(e.getCustomerExceptionGroup().getHttpCode(),
+                e.getCustomerExceptionGroup().getErrorCode(),
+                e.getCustomerExceptionGroup().getMessage());
     }
 
     /**


### PR DESCRIPTION
## 🔢 이슈 번호
- https://github.com/sayingpotato/Backend/issues/62

<br/>

## ⚙ 이슈 사항
- customer 관련 API에 global exception이 적용되어 있지 않아서 커스터마이징한 global exception을 적용하고자 합니다.

<br/>

## 📁 관련 파일
- CustomerException, CustomerExceptionGlobal, ExceptionController

<br/>

## ✔ 해결 방법
- 전역 exception handler를 추가하고 customer 관련 예외 처리에 커스터마이징하여 적용하였습니다.

<br/>

## 📷 스크린샷
- 없습니다.