### PR TITLE
Api/bugfix sign up sign in(#64)

### DIFF
--- a/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
@@ -43,7 +43,7 @@ public class CustomerApi {
     @PostMapping("/api/v1/customers/signIn")
     public Result<TokenResponse> signIn(@RequestBody SignInRequest signInRequest) throws Exception {
         TokenResponse tokenResponse = customerSignInService.signIn(signInRequest.getLoginId(), signInRequest.getPassword());
-        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, tokenResponse);
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, customerSignInService.addCustomerStatus(tokenResponse, signInRequest.getLoginId()));
     }
 
     @PutMapping("/api/v1/customers/image") //MultipartFile을 처리하기 위해서 @RequestParam을 사용했다. 따라서 {image:이미지파일} 꼴로 넘겨 받아야한다.

--- a/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
@@ -1,5 +1,6 @@
 package iampotato.iampotato.domain.customer.api;
 
+import iampotato.iampotato.domain.customer.application.CertifyCustomerService;
 import iampotato.iampotato.domain.customer.application.CustomerImageService;
 import iampotato.iampotato.domain.customer.application.CustomerSignInService;
 import iampotato.iampotato.domain.customer.application.CustomerSignUpService;
@@ -8,10 +9,6 @@ import iampotato.iampotato.domain.customer.dto.*;
 import iampotato.iampotato.global.util.Result;
 import iampotato.iampotato.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -27,6 +24,7 @@ public class CustomerApi {
     private final CustomerSignInService customerSignInService;
     private final CustomerSignUpService customerSignUpService;
     private final CustomerImageService customerImageService;
+    private final CertifyCustomerService certifyCustomerService;
 
     @PostMapping("/api/v1/customers/signUp")
     public Result<SignUpResponse> signUp(@RequestBody SignUpRequest signUpRequest) throws Exception{    //회원 가입하는 POST API
@@ -52,6 +50,12 @@ public class CustomerApi {
         String customerId = SecurityUtil.getCurrentUserId();
         Customer customer = customerImageService.uploadImage(customerId, multipartFile);
         return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, new UploadImageResponse(customerId, customer.getCustomerImage()));
+    }
+
+    @PostMapping("/api/v1/customers/certify")
+    public Result<String> certifyCustomer(@RequestBody CertifyCustomerRequest certifyCustomerRequest) {
+        certifyCustomerService.certifyCustomer(certifyCustomerRequest.getId());
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, "NULL");
     }
 
     @GetMapping(value = "/image/view", produces = {"image/jpeg", "image/png", "image/gif"})

--- a/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/api/CustomerApi.java
@@ -55,7 +55,7 @@ public class CustomerApi {
     @PostMapping("/api/v1/customers/certify")
     public Result<String> certifyCustomer(@RequestBody CertifyCustomerRequest certifyCustomerRequest) {
         certifyCustomerService.certifyCustomer(certifyCustomerRequest.getId());
-        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, "NULL");
+        return new Result<>(Result.CODE_SUCCESS, Result.MESSAGE_OK, null);
     }
 
     @GetMapping(value = "/image/view", produces = {"image/jpeg", "image/png", "image/gif"})

--- a/src/main/java/iampotato/iampotato/domain/customer/application/CertifyCustomerService.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/application/CertifyCustomerService.java
@@ -1,0 +1,27 @@
+package iampotato.iampotato.domain.customer.application;
+
+import iampotato.iampotato.domain.customer.dao.CustomerRepository;
+import iampotato.iampotato.domain.customer.domain.Customer;
+import iampotato.iampotato.domain.customer.domain.CustomerStatus;
+import iampotato.iampotato.domain.customer.exception.CustomerException;
+import iampotato.iampotato.domain.customer.exception.CustomerExceptionGroup;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CertifyCustomerService {
+
+    private final CustomerRepository customerRepository;
+
+    @Transactional
+    public void certifyCustomer(String id) {
+        Optional<Customer> findCustomersById = customerRepository.findById(id);
+        Customer customer = findCustomersById.orElseThrow(() -> new CustomerException(CustomerExceptionGroup.CUSTOMER_ID_NULL));
+        customer.updateCustomerStatus(CustomerStatus.COMPLETE);
+    }
+}

--- a/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignInService.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignInService.java
@@ -26,12 +26,7 @@ public class CustomerSignInService {
 
     @Transactional
     public TokenResponse signIn(String loginId, String password) {
-        List<Customer> findCustomersByLoginId = customerRepository.findByLoginId(loginId);
-        if (findCustomersByLoginId.isEmpty()) {
-            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_ID_NULL);
-        }
-
-        Customer customer = findCustomersByLoginId.get(0);
+        Customer customer = customerRepository.findByLoginId(loginId).orElseThrow(() -> new CustomerException(CustomerExceptionGroup.CUSTOMER_ID_NULL));
 
         if (!customer.getPassword().equals(password)) {
             throw new CustomerException(CustomerExceptionGroup.CUSTOMER_PASSWORD_WRONG);
@@ -39,7 +34,7 @@ public class CustomerSignInService {
 
         // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
         // 이때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(findCustomersByLoginId.get(0).getId(), password);
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(customer.getId(), password);
 
         // 2. 실제 검증 (사용자 비밀번호 체크)이 이루어지는 부분
         // authenticate 매서드가 실행될 때 CustomUserDetailsService 에서 만든 loadUserByUsername 메서드가 실행
@@ -52,12 +47,7 @@ public class CustomerSignInService {
     }
 
     public TokenResponse addCustomerStatus(TokenResponse tokenResponse, String loginId) {
-        List<Customer> findCustomersByLoginId = customerRepository.findByLoginId(loginId);
-        if (findCustomersByLoginId.isEmpty()) {
-            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_ID_NULL);
-        }
-
-        Customer customer = findCustomersByLoginId.get(0);
+        Customer customer = customerRepository.findByLoginId(loginId).orElseThrow(() -> new CustomerException(CustomerExceptionGroup.CUSTOMER_ID_NULL));
         tokenResponse.setCustomerStatus(customer.getCustomerStatus());
         return tokenResponse;
     }

--- a/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignInService.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignInService.java
@@ -50,4 +50,15 @@ public class CustomerSignInService {
 
         return tokenResponse;
     }
+
+    public TokenResponse addCustomerStatus(TokenResponse tokenResponse, String loginId) {
+        List<Customer> findCustomersByLoginId = customerRepository.findByLoginId(loginId);
+        if (findCustomersByLoginId.isEmpty()) {
+            throw new CustomerException(CustomerExceptionGroup.CUSTOMER_ID_NULL);
+        }
+
+        Customer customer = findCustomersByLoginId.get(0);
+        tokenResponse.setCustomerStatus(customer.getCustomerStatus());
+        return tokenResponse;
+    }
 }

--- a/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignUpService.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/application/CustomerSignUpService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,10 +27,9 @@ public class CustomerSignUpService {
     }
 
     private void validateDuplicatedCustomerByLoginId(Customer customer) {
-        List<Customer> findCustomersByLoginId = customerRepository.findByLoginId(customer.getLoginId());
-        if (!findCustomersByLoginId.isEmpty()) {
+        Optional<Customer> findCustomersByLoginId = customerRepository.findByLoginId(customer.getLoginId());
+        if(findCustomersByLoginId.isPresent())
             throw new CustomerException(CustomerExceptionGroup.CUSTOMER_DUPLICATED_ID);
-        }
     }
 
     private void validateDuplicatedCustomerByNickname(Customer customer) {

--- a/src/main/java/iampotato/iampotato/domain/customer/dao/CustomerRepository.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/dao/CustomerRepository.java
@@ -27,10 +27,11 @@ public class CustomerRepository {
                 .getResultList();
     }
 
-    public List<Customer> findByLoginId(String loginId) {   //LoginId를 통해 모든 Customer 조회
-        return em.createQuery("select c from Customer c where c.loginId = :loginId", Customer.class)    //:loginId라고 하여 밑에서 setParameter를 통해 "loginId"의 value와 바인딩
+    public Optional<Customer> findByLoginId(String loginId) {   //LoginId를 통해 모든 Customer 조회
+        List<Customer> result = em.createQuery("select c from Customer c where c.loginId = :loginId", Customer.class)    //:loginId라고 하여 밑에서 setParameter를 통해 "loginId"의 value와 바인딩
                 .setParameter("loginId", loginId)   //위에 있는 :loginId가 여기 파리미터의 Key값과 바인딩 되어서 value가 위로 넘어가게 됌
                 .getResultList();
+        return result.stream().findAny();
     }
 
     public List<Customer> findByNickname(String nickname) { //Nickname을 통해 모든 Customer 조회

--- a/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
@@ -86,6 +86,10 @@ public class Customer implements UserDetails {
         this.customerImage = customerImage;
     }
 
+    public void updateCustomerStatus(CustomerStatus customerStatus) {
+        this.customerStatus = customerStatus;
+    }
+
     public CustomerImage parseImageInfo(MultipartFile multipartFile) throws Exception {
         if (multipartFile.isEmpty()) {  //들어오는 이미지 파일이 비어있으면 예외 메세지 출력하고 상위 호출 메서드로 예외를 던짐
             throw new CustomerException(CustomerExceptionGroup.CUSTOMER_IMAGE_NULL);

--- a/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
@@ -4,6 +4,8 @@ import iampotato.iampotato.domain.customer.exception.CustomerException;
 import iampotato.iampotato.domain.customer.exception.CustomerExceptionGroup;
 import lombok.*;
 import org.apache.commons.lang3.ObjectUtils;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -24,6 +26,7 @@ import java.util.*;
 @Builder    //==정적 팩토리 메서드에서 빌더 패턴으로 변경!==//
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
 public class Customer implements UserDetails {
 
     //==정적 팩토리 메서드==//
@@ -57,6 +60,7 @@ public class Customer implements UserDetails {
     private String nickname;
 
     @Enumerated(EnumType.STRING)
+    @ColumnDefault("'UNAUTHORIZED'")
     private CustomerStatus customerStatus;  //회원 가입 상태 [COMPLETE, UNAUTHORIZED]
 
     private LocalDateTime createdDate;

--- a/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/domain/Customer.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,12 +45,15 @@ public class Customer implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles = new ArrayList<>();
 
+    @NotNull
     private String loginId;
 
+    @NotNull
     private String password;
 
     private String ssn;
 
+    @NotNull
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/iampotato/iampotato/domain/customer/dto/CertifyCustomerRequest.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/dto/CertifyCustomerRequest.java
@@ -1,0 +1,8 @@
+package iampotato.iampotato.domain.customer.dto;
+
+import lombok.Data;
+
+@Data
+public class CertifyCustomerRequest {
+    private String id;
+}

--- a/src/main/java/iampotato/iampotato/domain/customer/dto/SignInRequest.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/dto/SignInRequest.java
@@ -2,6 +2,8 @@ package iampotato.iampotato.domain.customer.dto;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotNull;
+
 @Data
 public class SignInRequest {    //로그인 시 Request Body
 

--- a/src/main/java/iampotato/iampotato/domain/customer/dto/SignUpRequest.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/dto/SignUpRequest.java
@@ -2,6 +2,9 @@ package iampotato.iampotato.domain.customer.dto;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 @Data
 public class SignUpRequest {    //회원 가입시 RequestBody
     private String loginId;

--- a/src/main/java/iampotato/iampotato/domain/customer/dto/TokenResponse.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/dto/TokenResponse.java
@@ -1,5 +1,6 @@
 package iampotato.iampotato.domain.customer.dto;
 
+import iampotato.iampotato.domain.customer.domain.CustomerStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,6 +12,8 @@ public class TokenResponse {
 
     private String grantType;
     private String accessToken;
+
+    private CustomerStatus customerStatus;
 
     //    private String refreshToken;
 }

--- a/src/main/java/iampotato/iampotato/domain/customer/jwt/JwtTokenProvider.java
+++ b/src/main/java/iampotato/iampotato/domain/customer/jwt/JwtTokenProvider.java
@@ -59,6 +59,7 @@ public class JwtTokenProvider {
                 .grantType("Bearer")
                 .accessToken(accessToken)
 //                .refreshToken(refreshToken)
+
                 .build();
     }
 


### PR DESCRIPTION
## 🔢 이슈 번호
- https://github.com/sayingpotato/Backend/issues/64

<br/>

## ⚙ 이슈 사항
- signUp과 signIn API를 클라이언트와 연동하며 발생한 버그 수정
- signUp 시 Request DTO 필드인 loginId와 password에 NOT NULL 걸어놓기
- signIn 시 Response에 회원의 학생증 인증 여부 boolean도 함께 보내주기
- 학생증 인증 상태를 UNAUTHORIZED에서 COMPLETE로 바꿔주는 certifyCustomer API 개발하기

<br/>

## 📁 관련 파일
- CustomerApi, CertifyCustomerService, CertifyCustomerRequest, Customer, TokenResponse

<br/>

## ✔ 해결 방법
- Customer Entity 내 loginId, password 필드에 @NOT NULL 적용
- signIn의 Response DTO인 TokenResponse에 회원의 학생증 인증 여부 관련 필드인 CustomerStatus 필드도 추가
- 인증 여부 관련 필드인 CustomerStatus의 값을 변경해주는 certifyCustomer API 개발

<br/>

## 📷 스크린샷
- 없습니다.